### PR TITLE
Bump cloudsql-proxy alpine base image to 3.13.5

### DIFF
--- a/cloudsql-proxy/Dockerfile
+++ b/cloudsql-proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloudsql-docker/gce-proxy:1.19.1-alpine as builder
 
-FROM alpine:3.13.3
+FROM alpine:3.13.5
 
 LABEL source=git@github.com:kyma-project/kyma.git
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
`alpine:3.13.3` has known security vulnerabilities

Changes proposed in this pull request:

- Bumped `cloudsql-docker` base image to `alpine:3.13.5`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
