### PR TITLE
Add etcd v3.3.25 image

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,10 @@
 /minio-mc/ @m00g3n @aerfio @pPrecel @dbadura @tgorgol @kfurgol
 
 # The `cloudsql-proxy` repo
-/cloudsql-proxy/ @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @adamwalach @crabtree @kjaksik
+/cloudsql-proxy/ @piotrmiskiewicz @ksputo @jasiu001 @crabtree
+
+# The `etcd` repo
+/etcd/ @piotrmiskiewicz @ksputo @jasiu001 @crabtree
 
 # The `k8s-tools` repo
 /k8s-tools/ @adamwalach @Ressetkk @Halamix2 @dekiel @tehcyx @kasiakepka

--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -1,0 +1,20 @@
+FROM eu.gcr.io/kyma-project/external/quay.io/coreos/etcd:v3.3.25 as builder
+
+FROM alpine:3.13.5
+
+LABEL source=git@github.com:kyma-project/kyma.git
+
+RUN mkdir -p /var/etcd/
+RUN mkdir -p /var/lib/etcd/
+
+# Alpine Linux doesn't use pam, which means that there is no /etc/nsswitch.conf,
+# but Golang relies on /etc/nsswitch.conf to check the order of DNS resolving
+# (see https://github.com/golang/go/commit/9dee7771f561cf6aee081c0af6658cc81fac3918)
+# To fix this we just create /etc/nsswitch.conf and add the following line:
+RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
+EXPOSE 2379 2380
+
+COPY --from=builder --chown=nonroot /usr/local/bin/ /usr/local/bin/
+
+CMD ["/usr/local/bin/etcd"]

--- a/etcd/Makefile
+++ b/etcd/Makefile
@@ -1,0 +1,9 @@
+APP_NAME ?= quay.io/coreos/etcd
+VERSION = v3.3.25
+TAG = $(VERSION)-$(DOCKER_TAG)
+IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME):$(TAG)
+IMG_DOCKER_TAG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME):$(DOCKER_TAG)
+
+# Use generic makefile
+COMMON_DIR = $(realpath $(shell pwd)/../)/common
+include $(COMMON_DIR)/generic_makefile.mk

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -1,0 +1,5 @@
+# etcd
+
+This folder contains the etcd image that is based on the official [etcd v3.3.25 image](https://github.com/etcd-io/etcd/tree/v3.3.25).
+
+This custom image has been created to mitigate the security vulnerabilities the official image has.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Etcd image we used needed to be rebuilt with using latest `alpine:3.3.15` to mitigate known security vulnerabilities

Changes proposed in this pull request:

- Added `etcd` image to third party images from https://github.com/etcd-io/etcd/blob/v3.3.25/Dockerfile-release

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
