### PR TITLE
Adding Cosign to the k8s-tools image

### DIFF
--- a/k8s-tools/Dockerfile
+++ b/k8s-tools/Dockerfile
@@ -1,7 +1,15 @@
+FROM golang:1.16 as builder
+
+RUN go get github.com/sigstore/cosign@v0.5.0
+
+RUN cd /go/pkg/mod/github.com/sigstore/cosign\@v0.5.0 &&\
+    make cosign
+
+
+
 FROM alpine:3.13.5
 
 # Commit details
-
 
 ARG commit
 ENV IMAGE_COMMIT=$commit
@@ -15,5 +23,7 @@ RUN apk --no-cache upgrade &&\
     apk --no-cache add openssl coreutils curl bash jq grep inotify-tools &&\
     wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl &&\
     chmod +x /usr/local/bin/kubectl
+
+COPY --from=builder /go/pkg/mod/github.com/sigstore/cosign\@v0.5.0/cosign usr/local/bin/cosign
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
As part of securing the images, we are adding cosign the k8s-tools
image. This will allow the signing of the images.

The version is hard-coded to prevent any future new breaking updates. 
We are also using a two-stage build.

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>

