### PR TITLE
Cosign intro - Adding target and key URL

### DIFF
--- a/common/generic_makefile.mk
+++ b/common/generic_makefile.mk
@@ -28,6 +28,11 @@ ci-tag:
 .PHONY: ci-pr
 ci-pr: docker-build ci-tag docker-push docker-push-pr
 
+# Cosign signing
+.PHONY: cosign-pr
+cosign-pr: ci-pr
+	cosign sign -key ${KMS_KEY_URL} ${IMG_DOCKER_TAG}
+
 .PHONY: ci-main
 ci-main: docker-build docker-push
 

--- a/k8s-tools/Dockerfile
+++ b/k8s-tools/Dockerfile
@@ -1,12 +1,3 @@
-FROM golang:1.16 as builder
-
-RUN go get github.com/sigstore/cosign@v0.5.0
-
-RUN cd /go/pkg/mod/github.com/sigstore/cosign\@v0.5.0 &&\
-    make cosign
-
-
-
 FROM alpine:3.13.5
 
 # Commit details
@@ -23,7 +14,5 @@ RUN apk --no-cache upgrade &&\
     apk --no-cache add openssl coreutils curl bash jq grep inotify-tools &&\
     wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl &&\
     chmod +x /usr/local/bin/kubectl
-
-COPY --from=builder /go/pkg/mod/github.com/sigstore/cosign\@v0.5.0/cosign usr/local/bin/cosign
 
 ENTRYPOINT ["/bin/bash"]

--- a/k8s-tools/Dockerfile
+++ b/k8s-tools/Dockerfile
@@ -1,7 +1,15 @@
+FROM golang:1.16 as builder
+
+RUN go get github.com/sigstore/cosign@v0.5.0
+
+RUN cd /go/pkg/mod/github.com/sigstore/cosign\@v0.5.0 &&\
+    make cosign
+
+
+
 FROM alpine:3.13.5
 
 # Commit details
-
 
 ARG commit
 ENV IMAGE_COMMIT=$commit
@@ -15,5 +23,7 @@ RUN apk --no-cache upgrade &&\
     apk --no-cache add openssl coreutils curl bash jq grep inotify-tools &&\
     wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl &&\
     chmod +x /usr/local/bin/kubectl
+
+COPY --from=builder /go/pkg/mod/github.com/sigstore/cosign\@v0.5.0/cosign usr/local/bin/cosign
 
 ENTRYPOINT ["/bin/bash"]

--- a/k8s-tools/Makefile
+++ b/k8s-tools/Makefile
@@ -3,6 +3,7 @@ APP_VERSION = $(shell date +'%Y%m%d')
 TAG = $(APP_VERSION)-$(DOCKER_TAG)
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME):$(TAG)
 IMG_DOCKER_TAG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME):$(DOCKER_TAG)
+KMS_KEY_URL ?= gcpkms://projects/sap-kyma-neighbors-dev/locations/global/keyRings/test-cosign-asym/cryptoKeys/whatever3
 
 # Use generic makefile
 COMMON_DIR = $(realpath $(shell pwd)/../)/common


### PR DESCRIPTION
As part of securing the images, we are adding a new target for the k8s-tools image.
This will allow the signing of the images.

Also adding a variable that points to the KMS hosted key.

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>