### PR TITLE
Remove kazydek from CODEOWNERS & add NHingerl

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,4 +30,4 @@
 /console-nginx/ @akucharska @dariadomagala @parostatkiem @Wawrzyn321
 
 # All .md files
-*.md @majakurcius @kazydek @klaudiagrz @alexandra-simeonova @mmitoraj
+*.md @majakurcius @klaudiagrz @alexandra-simeonova @mmitoraj @NHingerl


### PR DESCRIPTION
**Description**

As Karolina is no longer an active contributor to the project, they must be removed from the CODEOWNERS. 
As Nina's been actively contributing to Kyma for some time now, she, in turn, must be added.

Changes proposed in this pull request:

- Remove @kazydek from CODEOWNERS
- Add @NHingerl to CODEOWNERS