### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,10 +21,10 @@
 /kaniko-executer/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93 @moelsayed
 
 # The `cloudsql-proxy` repo
-/cloudsql-proxy/ @piotrmiskiewicz @ksputo @jasiu001 @crabtree
+/cloudsql-proxy/ @piotrmiskiewicz @ksputo 
 
 # The `etcd` repo
-/etcd/ @piotrmiskiewicz @ksputo @jasiu001 @crabtree
+/etcd/ @piotrmiskiewicz @ksputo 
 
 # The `k8s-tools` repo
 /k8s-tools/ @kyma-project/prow


### PR DESCRIPTION
Krystian and Piotr left Kyma and they're no longer active contributors so, according to the [guidelines](https://kyma-project.io/community/governance/01-governance/#when-does-a-maintainer-lose-the-maintainer-status), they can be removed from the codeowners.

Changes proposed in this pull request:

- Remove Krystian (`crabtree`) and Piotr (`jasiu001`) from codeowners
