### PR TITLE
Bump kubectl to 1.21.9 & Alpine to 3.15.0 in k8s-tools

### DIFF
--- a/k8s-tools/Dockerfile
+++ b/k8s-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 
 # Commit details
 
@@ -11,8 +11,7 @@ LABEL source=git@github.com:kyma-project/third-party-images.git
 ENV KUBECTL_VERSION="v1.21.9"
 
 RUN apk --no-cache upgrade &&\
-    apk add --no-cache wget>=1.21.2-r2  ncurses>=6.2_p20211009-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main &&\
-    apk --no-cache add openssl coreutils curl bash jq grep inotify-tools &&\
+    apk --no-cache add wget ncurses openssl coreutils curl bash jq grep inotify-tools &&\
     wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl &&\
     chmod +x /usr/local/bin/kubectl
 

--- a/k8s-tools/Dockerfile
+++ b/k8s-tools/Dockerfile
@@ -8,7 +8,7 @@ LABEL io.kyma-project.third-party-images.commit=$commit
 
 LABEL source=git@github.com:kyma-project/third-party-images.git
 
-ENV KUBECTL_VERSION="v1.19.15"
+ENV KUBECTL_VERSION="v1.21.9"
 
 RUN apk --no-cache upgrade &&\
     apk add --no-cache wget>=1.21.2-r2  ncurses>=6.2_p20211009-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main &&\


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump kubectl to 1.21.9 in k8s-tools
- Bump Alpine to 3.15.0
    - remove pinning `wget` and `ncurses`, Alpine 3.15 contains non-vulnerable versions

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
