### PR TITLE
Add grego952 as a documentation CODEOWNER in Third-Party Images 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,4 +51,4 @@
 /k8s-tools/ @kyma-project/prow
 
 # All .md files
-*.md @majakurcius @klaudiagrz @alexandra-simeonova @mmitoraj @NHingerl
+*.md @majakurcius @klaudiagrz @alexandra-simeonova @mmitoraj @NHingerl @grego952


### PR DESCRIPTION
**Description**

As @grego952 has been working with Kyma for over 3 months as a Technical Writer and has gained expertise in this domain, he should be added to the documentation CODEOWNERS.

Changes proposed in this pull request:

- Add @grego952 to Third-Party Images documentation CODEOWNERS

**Related issue**
[#13077 ](https://github.com/kyma-project/kyma/issues/13077)
