### PR TITLE
Bump CloudSQL image to v1.28.1

### DIFF
--- a/cloudsql-proxy/Dockerfile
+++ b/cloudsql-proxy/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcr.io/cloudsql-docker/gce-proxy:1.28.0-alpine as builder
+FROM gcr.io/cloudsql-docker/gce-proxy:1.28.1-alpine as builder
 
-FROM alpine:3.14.3
+FROM alpine:3.15.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Using latest upstream CloudSQL proxy image to remediate [OpenSSL CVE-2021-4160](https://nvd.nist.gov/vuln/detail/CVE-2021-4160).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
