### PR TITLE
Bump etcd alpine base to 3.15.0 and OpenSSL to 1.1.1l-r7

### DIFF
--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -2,10 +2,11 @@ FROM eu.gcr.io/kyma-project/external/quay.io/coreos/etcd:v3.3.25 as builder
 
 # builder relies on https://github.com/etcd-io/etcd/blob/v3.3.25/Dockerfile-release
 
-FROM alpine:3.14.2
+FROM alpine:3.15.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
+RUN apk --no-cache add --update openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN mkdir -p /var/etcd/
 RUN mkdir -p /var/lib/etcd/
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

OpenSSL from edge has version [1.1.1m-r1](https://pkgs.alpinelinux.org/package/edge/main/x86/openssl#), this is to remediate CVE-2021-4160 present in current `1.1.1l-r7`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
