### PR TITLE
Install OpenSSL dev from edge

### DIFF
--- a/cloudsql-proxy/Dockerfile
+++ b/cloudsql-proxy/Dockerfile
@@ -4,6 +4,7 @@ FROM alpine:3.15.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
+RUN apk --no-cache add --update openssl openssl-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk --no-cache upgrade && \
     apk --no-cache add \ 
     ca-certificates \

--- a/cloudsql-proxy/Dockerfile
+++ b/cloudsql-proxy/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.15.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-RUN apk --no-cache add --update openssl openssl-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add --update openssl openssl-dev --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk --no-cache upgrade && \
     apk --no-cache add \ 
     ca-certificates \

--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3.15.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-RUN apk --no-cache add --update openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add --update openssl openssl-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN mkdir -p /var/etcd/
 RUN mkdir -p /var/lib/etcd/
 

--- a/etcd/Dockerfile
+++ b/etcd/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3.15.0
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-RUN apk --no-cache add --update openssl openssl-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add --update openssl openssl-dev --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN mkdir -p /var/etcd/
 RUN mkdir -p /var/lib/etcd/
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Recently, I updated only OpenSSL client but not the library, which was still installed from the stable repo.
```
$ docker run img openssl version
OpenSSL 1.1.1m  14 Dec 2021 (Library: OpenSSL 1.1.1l  24 Aug 2021)
```
this ensures the library is also the latest available from edge and not vulnerable to https://github.com/advisories/GHSA-ph2x-8239-7xc7
```
$ docker run img openssl version
OpenSSL 1.1.1m  14 Dec 2021
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/third-party-images/pull/181, https://github.com/kyma-project/third-party-images/pull/182