### PR TITLE
Fix CVE-2022-23806 for Kaniko

### DIFF
--- a/kaniko-executer/Dockerfile
+++ b/kaniko-executer/Dockerfile
@@ -14,7 +14,7 @@
 
 # Builds the static Go image to execute in a Kubernetes job
 
-FROM eu.gcr.io/kyma-project/external/golang:1.17.6-alpine3.15 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.17.7-alpine3.15 as builder
 
 ARG KANIKO_VERSION
 ARG GOARCH=amd64

--- a/kaniko-executer/Dockerfile
+++ b/kaniko-executer/Dockerfile
@@ -53,6 +53,7 @@ RUN mkdir -p /kaniko/.docker
 
 RUN git clone --depth 1 --branch v$KANIKO_VERSION https://github.com/GoogleContainerTools/kaniko . \
   && go mod edit -replace code.gitea.io/sdk/gitea=code.gitea.io/sdk/gitea@v0.15.1 \
+  && go mod edit -go=1.17 \
   && go mod vendor \
   && make GOARCH=$(cat /goarch)
 


### PR DESCRIPTION
**Description**
Upgraded GoLang version in order to fix security vulnerability.