### PR TITLE
Set loki plugin go version back to 1.17

### DIFF
--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -72,7 +72,7 @@ RUN cp conf/fluent-bit.conf \
      conf/plugins.conf \
      /fluent-bit/etc/
 
-FROM golang:1.18 as lokibuilder
+FROM golang:1.17 as lokibuilder
 
 # 2.2.x is the last version on Apache 2.0 license, please verify the license before upgrading further
 ENV LOKI_VERSION 2.2.1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Set Loki builder to 1.17 since 1.18 crashes
  
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/13806