### PR TITLE
Fix documentation CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 # These are the default owners for the whole content of the `fluentbit` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 * @a-thaler @PK85 @pbochynski @kwiatekus
 
-/.github/ISSUE_TEMPLATE @nhingerl @grego952 @klaudiagrz @majakurcius @mmitoraj
+/.github/ISSUE_TEMPLATE @NHingerl @grego952 @klaudiagrz @majakurcius @mmitoraj
 /.github @kyma-project/prow
 /cloudsql-proxy @ralikio @szwedm @tillknuesting @wozniakjan @hanngos @piotrmiskiewicz @pk85
 /common @kyma-project/prow
@@ -27,4 +27,4 @@
 /prometheus-node-exporter @a-thaler @chrkl @dennis-ge @lindnerby @rakesh-garimella @skhalash
 
 # All .md files
-*.md @bszwarc @majakurcius @tomekpapiernik @kazydek @klaudiagrz @alexandra-simeonova @mmitoraj
+*.md @majakurcius @klaudiagrz @NHingerl @mmitoraj @grego952


### PR DESCRIPTION
**Description**

The CODEOWNERS file contains certain people that have not been active contributors for a long time. They should not be there. This PR removes them. 
There were also some CODEOWNERS missing. This PR adds them.

Changes proposed in this pull request:

- Remove @bszwarc, @tomekpapiernik, @kazydek, and @alexandra-simeonova from the documentation CODEOWNERS
- Add @NHingerl and @grego952 to the documentation CODEOWNERS
- Fix a typo (lowercase -> uppercase) in @NHingerl's GitHub handle in the CODEOWNERS file

**Related PR**
https://github.com/kyma-project/third-party-images/pull/218