### PR TITLE
Use upstream Fluent Bit base image

### DIFF
--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -2,7 +2,7 @@ ARG FLB_VERSION
 FROM fluent/fluent-bit:${FLB_VERSION} as fluentbit
 
 # build sequential_http plugin
-FROM debian:testing-20220509-slim as plugin-builder
+FROM debian:bullseye-slim as plugin-builder
 ARG FLB_VERSION
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL

--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -79,3 +79,4 @@ COPY --from=loki-builder /loki/out_grafana_loki.so /fluent-bit/lib/out_grafana_l
 
 LABEL source=git@github.com:kyma-project/kyma.git
 CMD ["/fluent-bit/bin/fluent-bit", "-e", "/fluent-bit/lib/flb-out_sequentialhttp.so", "-e", "/fluent-bit/lib/out_grafana_loki.so", "-c", "/fluent-bit/etc/fluent-bit.conf"]
+

--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -1,7 +1,9 @@
-FROM debian:testing-20220509-slim as builder
-
 ARG FLB_VERSION
+FROM fluent/fluent-bit:${FLB_VERSION} as fluentbit
 
+# build sequential_http plugin
+FROM debian:testing-20220509-slim as plugin-builder
+ARG FLB_VERSION
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
@@ -35,6 +37,7 @@ RUN apt-get update && \
     && rm -rf /tmp/fluent-bit/build/*
 
 WORKDIR /tmp/fluent-bit/build/
+
 RUN cmake -DFLB_RELEASE=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \
@@ -49,7 +52,6 @@ RUN cmake -DFLB_RELEASE=On \
 RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
-# Add sequentialhttp
 RUN rm -rf /plugins
 COPY plugins /plugins
 RUN mkdir -p /plugins/build/
@@ -57,25 +59,10 @@ WORKDIR /plugins/build/
 RUN cmake -DFLB_SOURCE=/tmp/fluent-bit \
           -DPLUGIN_NAME=out_sequentialhttp  ../
 RUN make -j $(getconf _NPROCESSORS_ONLN)
-# End sequentialhttp
 
-# Configuration files
-WORKDIR /tmp/fluent-bit/
-RUN mkdir /fluent-bit/lib
-RUN cp conf/fluent-bit.conf \
-     conf/parsers.conf \
-     conf/parsers_ambassador.conf \
-     conf/parsers_java.conf \
-     conf/parsers_extra.conf \
-     conf/parsers_openstack.conf \
-     conf/parsers_cinder.conf \
-     conf/plugins.conf \
-     /fluent-bit/etc/
-
-FROM golang:1.17 as lokibuilder
-
-# 2.2.x is the last version on Apache 2.0 license, please verify the license before upgrading further
-ENV LOKI_VERSION 2.2.1
+# build loki plugin
+FROM golang:1.17 as loki-builder
+ARG LOKI_VERSION
 
 RUN mkdir -p /tmp/src /loki
 RUN curl -L https://github.com/grafana/loki/archive/v${LOKI_VERSION}.tar.gz | \
@@ -84,26 +71,11 @@ WORKDIR /tmp/src
 RUN make clean && make BUILD_IN_CONTAINER=false fluent-bit-plugin 
 RUN cp /tmp/src/cmd/fluent-bit/out_grafana_loki.so /loki
 
-FROM debian:testing-20220509-slim
+# Take upstream image and copy over our plugins
+FROM fluentbit
 
-RUN apt-get update && \
-    apt-get -y dist-upgrade && \
-    apt-get install -y --no-install-recommends \
-    libsasl2-2 \
-    libssl1.1 \
-    ca-certificates && \
-    rm -rf /var/lib/apt/lists
-
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libpq.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libldap* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/liblber* /usr/lib/x86_64-linux-gnu/
-
-COPY --from=builder /fluent-bit /fluent-bit
-COPY --from=builder /plugins/build/flb-out_sequentialhttp.so /fluent-bit/lib
-COPY --from=lokibuilder /loki/out_grafana_loki.so /fluent-bit/lib
-
-EXPOSE 2020
+COPY --from=plugin-builder /plugins/build/flb-out_sequentialhttp.so /fluent-bit/lib/flb-out_sequentialhttp.so
+COPY --from=loki-builder /loki/out_grafana_loki.so /fluent-bit/lib/out_grafana_loki.so
 
 LABEL source=git@github.com:kyma-project/kyma.git
 CMD ["/fluent-bit/bin/fluent-bit", "-e", "/fluent-bit/lib/flb-out_sequentialhttp.so", "-e", "/fluent-bit/lib/out_grafana_loki.so", "-c", "/fluent-bit/etc/fluent-bit.conf"]
-

--- a/fluent-bit/Makefile
+++ b/fluent-bit/Makefile
@@ -1,5 +1,7 @@
 APP_NAME ?= fluent-bit
 FLUENTBIT_VERSION = 1.9.3
+# 2.2.x is the last version on Apache 2.0 license, please verify the license before upgrading further
+LOKI_VERSION = 2.2.1
 TAG = $(FLUENTBIT_VERSION)-$(DOCKER_TAG)
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME):$(TAG)
 IMG_DOCKER_TAG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME):$(DOCKER_TAG)
@@ -10,5 +12,5 @@ include $(COMMON_DIR)/generic_makefile.mk
 
 # override docker-build 
 docker-build:
-	docker build . -t ${IMG} --build-arg FLB_VERSION=$(FLUENTBIT_VERSION)
+	docker build . -t ${IMG} --build-arg FLB_VERSION=$(FLUENTBIT_VERSION) --build-arg LOKI_VERSION=$(LOKI_VERSION)
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The fluent-bit image was self-builded and based on a debian testing image. The main motivation was to use latest dependency version to avoid security investigations on known vulnerabilities of dependencies not being fixed in the debian stable release.
The downside of that approach is that a distroless image cannot be used and with that there are much more dependencies as part of the image. So using the upstream image is in favor as it contains less dependencies at runtime and also will not require to build fluent-bit in a custom way.

As recently bullseye got promoted to be the new stable, there are no prominent CVEs which are fixed in testing but in stable. We should use the chance of switching back and try to triage potential CVE which are not getting fixed more hard.


Changes proposed in this pull request:

- make the main image based on the upstream image, do not re-build the binary for that
- keep the build of the two plugins for now and just copy them over

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
