### PR TITLE
Fix CVE-2022-1996 for kube-state-metrics tpi

### DIFF
--- a/kube-state-metrics/Dockerfile
+++ b/kube-state-metrics/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /src/ksm
 ADD https://github.com/kubernetes/kube-state-metrics/archive/refs/tags/v${KSM_VERSION}.tar.gz /ksm.tar.gz
 RUN tar -xz --strip-components=1 --directory=/src/ksm --file=/ksm.tar.gz
 
+# fix compatibility issue with golang 1.19
+RUN go get github.com/emicklei/go-restful/v3@v3.9.0
+RUN go mod vendor
+
 RUN make build-local
 
 FROM scratch


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- CVE-2022-1996 needs update of go-restful dependency

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
