### PR TITLE
Update Golang Builder Version to 1.20.3

### DIFF
--- a/docker-registry/Dockerfile
+++ b/docker-registry/Dockerfile
@@ -1,5 +1,5 @@
-# image builder base on golang:1.20.2-alpine3.17
-FROM eu.gcr.io/kyma-project/external/golang@sha256:4e6bc0eafc261b6c8ba9bd9999b6698e8cefbe21e6d90fbc10c34599d75dc608 as builder
+# image builder base on golang:1.20.3-alpine3.17
+FROM eu.gcr.io/kyma-project/external/golang@sha256:48c87cd759e3342fcbc4241533337141e7d8457ec33ab9660abe0a4346c30b60 as builder
 
 ENV GO111MODULE=auto
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution

--- a/kaniko-executer/Dockerfile
+++ b/kaniko-executer/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# image builder base on golang:1.20.2-alpine3.17
-FROM eu.gcr.io/kyma-project/external/golang@sha256:4e6bc0eafc261b6c8ba9bd9999b6698e8cefbe21e6d90fbc10c34599d75dc608 as builder
+# image builder base on golang:1.20.3-alpine3.17
+FROM eu.gcr.io/kyma-project/external/golang@sha256:48c87cd759e3342fcbc4241533337141e7d8457ec33ab9660abe0a4346c30b60 as builder
 
 ARG KANIKO_VERSION
 ARG GOARCH=amd64


### PR DESCRIPTION
**Description**
Bumping to 1.20.3 (Security related)