### PR TITLE
add feature gate to otel-collector to use LocalHost As Default Host

### DIFF
--- a/otel-collector/Dockerfile
+++ b/otel-collector/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=build --chmod=755 /app/kyma-otelcol /
 
 USER 65532:65532
 
-ENTRYPOINT ["/kyma-otelcol"]
+ENTRYPOINT ["/kyma-otelcol", "--feature-gates=+component.UseLocalHostAsDefaultHost"]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently a warning pops up in the startup phase:
```json
{"level":"warn","ts":1710287522.1744921,"caller":"localhostgate/featuregate.go:63","msg":"The default endpoints for all servers in components will change to use localhost instead of 0.0.0.0 in a future version. Use the feature gate to preview the new default.","feature gate ID":"component.UseLocalHostAsDefaultHost"}
```

Changes proposed in this pull request:

- Add feature gate to the command to switch already to the new default in order to suppress the warning
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
